### PR TITLE
Add simple item groups

### DIFF
--- a/nupkg/build/Unity3D.props
+++ b/nupkg/build/Unity3D.props
@@ -57,7 +57,7 @@
 
   <!-- Add default Unity references -->
   <ItemGroup>
-    <Reference Include="$(UnityInstallRoot)\$(UnityVersion)\$(UnityEnginePath)" Private="false" />
+    <UnityReference Include="UnityEngine" Private="false" />
   </ItemGroup>
 
 </Project>

--- a/nupkg/build/Unity3D.targets
+++ b/nupkg/build/Unity3D.targets
@@ -1,0 +1,56 @@
+<Project InitialTargets="AddUnityReferences;AddUnityAssemblyReferences;AddUnityProjectReferences;AddUnityProjectAssemblyReferences;AddUnityScriptAssemblyReferences;AddUnityPackageCacheReferences">
+    <!-- UnityReference: Use short-hand names for editor assemblies e.g. UnityEngine, UnityEditor, UnityEngineUI -->
+    <Target Name="AddUnityReferences"
+            Inputs="@(UnityReference)"
+            Outputs="$(UnityInstallRoot)\$(UnityVersion)\$(%(UnityReference.Identity)Path)">
+        <ItemGroup>
+            <Reference Include="$(UnityInstallRoot)\$(UnityVersion)\$(%(UnityReference.Identity)Path)"
+                       Private="%(UnityReference.Private)"/>
+        </ItemGroup>
+    </Target>
+    <!-- UnityAssemblyReference: Use relative path for editor assemblies -->
+    <Target Name="AddUnityAssemblyReferences"
+            Inputs="@(UnityAssemblyReference)"
+            Outputs="$(UnityInstallRoot)\$(UnityVersion)\%(UnityAssemblyReference.Identity)">
+        <ItemGroup>
+            <Reference Include="$(UnityInstallRoot)\$(UnityVersion)\%(UnityAssemblyReference.Identity)"
+                       Private="%(UnityAssemblyReference.Private)"/>
+        </ItemGroup>
+    </Target>
+    <!-- UnityProjectReference: Use relative path for project assemblies or short-hand names e.g. UnityAnalyticsStandardEvents -->
+    <Target Name="AddUnityProjectReferences"
+            Inputs="@(UnityProjectReference)"
+            Outputs="$(UnityProjectPath)\$(%(UnityProjectReference.Identity)Path)">
+        <ItemGroup>
+            <Reference Include="$(UnityProjectPath)\$(%(UnityProjectReference.Identity)Path)"
+                       Private="%(UnityProjectReference.Private)"/>
+        </ItemGroup>
+    </Target>
+    <!-- UnityProjectAssemblyReference: Use relative path for project assemblies or short-hand names e.g. UnityAnalyticsStandardEvents -->
+    <Target Name="AddUnityProjectAssemblyReferences"
+            Inputs="@(UnityProjectAssemblyReference)"
+            Outputs="$(UnityProjectPath)\%(UnityProjectAssemblyReference.Identity)">
+        <ItemGroup>
+            <Reference Include="$(UnityProjectPath)\%(UnityProjectAssemblyReference.Identity)"
+                       Private="%(UnityProjectAssemblyReference.Private)"/>
+        </ItemGroup>
+    </Target>
+    <!-- UnityScriptAssemblyReference: Use relative path for project ScriptAssemblies assemblies -->
+    <Target Name="AddUnityScriptAssemblyReferences"
+            Inputs="@(UnityScriptAssemblyReference)"
+            Outputs="$(UnityProjectPath)\$(UnityScriptAssembliesPath)\%(UnityScriptAssemblyReference.Identity)">
+        <ItemGroup>
+            <Reference Include="$(UnityProjectPath)\$(UnityScriptAssembliesPath)\%(UnityScriptAssemblyReference.Identity)"
+                       Private="%(UnityScriptAssemblyReference.Private)"/>
+        </ItemGroup>
+    </Target>
+    <!-- UnityPackageCacheReference: Use relative path for project PackageCache assemblies -->
+    <Target Name="AddUnityPackageCacheReferences"
+            Inputs="@(UnityPackageCacheReference)"
+            Outputs="$(UnityProjectPath)\$(UnityPackageCachePath)\%(UnityPackageCacheReference.Identity)">
+        <ItemGroup>
+            <Reference Include="$(UnityProjectPath)\$(UnityPackageCachePath)\%(UnityPackageCacheReference.Identity)"
+                       Private="%(UnityPackageCacheReference.Private)"/>
+        </ItemGroup>
+    </Target>
+</Project>

--- a/nupkg/buildMultiTargeting/Unity3D.targets
+++ b/nupkg/buildMultiTargeting/Unity3D.targets
@@ -1,0 +1,3 @@
+﻿<Project>
+  <Import Project="..\build\Unity3D.targets" />
+</Project>


### PR DESCRIPTION
For most cases the use of long `Include` strings seems redundant.
This PR adds some new item groups processed as initial targets. They're translated to equivalent `Reference` items.
* UnityReference: short-hand editor assemblies
  - `<UnityReference Include="UnityEngine"/>`
* UnityAssemblyReference: editor assembly dlls
  - `<UnityAssemblyReference Include="$(UnityManagedPath)\UnityEngine.dll"/>`
* UnityProjectReference: short-hand project assemblies
  - `<UnityProjectReference Include="UnityAnalyticsStandardEvents"/>`
* UnityProjectAssemblyReference: project assembly dlls
  - `<UnityProjectAssemblyReference Include="$(UnityScriptAssembliesPath)\UnityEngine.UI.dll"/>`
* UnityScriptAssemblyReference: short-hand ScriptAssembly assembly dlls
  - `<UnityScriptAssemblyReference Include="Unity.Addressables.dll"/>`
* UnityPackageCacheReference: short-hand PackageCache assembly dlls
  - `<UnityPackageCacheReference Include="com.unity.burst@1.4.3\Unity.Burst.Unsafe.dll"/>`
